### PR TITLE
Fix memberof to mdb database

### DIFF
--- a/georchestra-memberof.ldif
+++ b/georchestra-memberof.ldif
@@ -4,7 +4,7 @@ cn: module
 olcModulePath: /usr/lib/ldap
 olcModuleLoad: memberof
 
-dn: olcOverlay=memberof,olcDatabase={1}hdb,cn=config
+dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
 objectClass: olcMemberOf
 objectClass: olcOverlayConfig
 objectClass: olcConfig


### PR DESCRIPTION
Other ldif of master switch to mdb database, so get an error when use memberof in this branch