### PR TITLE
Use groupOfMembers instead of groupOfNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository holds the required files to configure and populate an OpenLDAP d
 
 Please refer to the [geOrchestra documentation](https://github.com/georchestra/georchestra/blob/master/README.md) for instructions, and **use the branch matching your geOrchestra version** !
 
+## georchestra-groupofmembers.ldif
+
+This file imports ```groupOfMembers``` LDAP objectClass into OpenLdap available schemas. It allows to have empty groups, which the default ```groupOfNames``` doesn't permit. ```groupOfMembers``` comes from RFC2037bis and is used in lots of places.
 
 ## georchestra-bootstrap.ldif
 

--- a/csv2ldif/CSV2LDIF.py
+++ b/csv2ldif/CSV2LDIF.py
@@ -121,7 +121,7 @@ for row in inputReader:
 
 for groupName,o in groups.items():
     print "dn: cn=" + groupName + ",ou=groups," + LDAP_ROOT_DN + EOL,
-    print "objectClass: groupOfNames" + EOL,
+    print "objectClass: groupOfMembers" + EOL,
     print "objectClass: top" + EOL,
     print "cn: " + groupName + EOL,
     for member in o['users']:

--- a/geofence-uniqueids/add-unique-ids.py
+++ b/geofence-uniqueids/add-unique-ids.py
@@ -25,7 +25,7 @@ USERS_UID_ATTRIBUTE='employeeNumber'
 USERS_LDAP_FILTER='(&(objectClass=%s)(!(%s=*)))' % (USERS_OBJ_CLASS,USERS_UID_ATTRIBUTE,)
 USERS_LDAP_BASEDN='ou=users,dc=georchestra,dc=org'
 
-GROUPS_OBJ_CLASS='groupOfNames'
+GROUPS_OBJ_CLASS='groupOfMembers'
 GROUPS_UID_ATTRIBUTE='ou'
 GROUPS_LDAP_FILTER='(&(objectClass=%s)(!(%s=*)))' % (GROUPS_OBJ_CLASS, GROUPS_UID_ATTRIBUTE,)
 GROUPS_LDAP_BASEDN='ou=groups,dc=georchestra,dc=org'

--- a/georchestra-groupofmembers.ldif
+++ b/georchestra-groupofmembers.ldif
@@ -1,0 +1,10 @@
+dn: cn=groupOfMembers, cn=schema, cn=config
+objectClass: olcSchemaConfig
+cn: groupOfMembers
+olcObjectClasses: ( 1.3.6.1.1.1.2.18
+    NAME 'groupOfMembers'
+    DESC 'RFC2307bis: a group with members (DNs)'
+    SUP top
+    STRUCTURAL
+    MUST cn
+    MAY ( businessCategory $ seeAlso $ owner $ ou $ o $ description $ member ) )

--- a/georchestra-memberof.ldif
+++ b/georchestra-memberof.ldif
@@ -12,6 +12,6 @@ objectClass: top
 olcOverlay: memberof
 olcMemberOfDangling: ignore
 olcMemberOfRefInt: FALSE
-olcMemberOfGroupOC: groupOfNames
+olcMemberOfGroupOC: groupOfMembers
 olcMemberOfMemberAD: member
 olcMemberOfMemberOfAD: memberOf

--- a/georchestra.ldif
+++ b/georchestra.ldif
@@ -99,7 +99,6 @@ ou: 1
 description: This group grants admin access to GeoServer
 member: uid=geoserver_privileged_user,ou=users,dc=georchestra,dc=org
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 
 # PENDING_USERS, groups, georchestra.org
@@ -109,7 +108,6 @@ objectClass: groupOfMembers
 cn: PENDING_USERS
 ou: 2
 description: This group does not grant any right inside the SDI. Users in this group are requesting a fully fledged account.
-member: uid=fakeuser
 
 
 # MOD_LDAPADMIN, groups, georchestra.org
@@ -120,7 +118,6 @@ cn: MOD_LDAPADMIN
 ou: 10
 description: This group grants access to the LDAPadmin private User Interface
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 # MOD_ANALYTICS, groups, georchestra.org
 dn: cn=MOD_ANALYTICS,ou=groups,dc=georchestra,dc=org
@@ -130,7 +127,6 @@ cn: MOD_ANALYTICS
 ou: 11
 description: This group grants access to the Analytics application
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 # MOD_EXTRACTORAPP, groups, georchestra.org
 dn: cn=MOD_EXTRACTORAPP,ou=groups,dc=georchestra,dc=org
@@ -140,7 +136,6 @@ cn: MOD_EXTRACTORAPP
 ou: 12
 description: This group grants access to the Extractorapp application
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 
 # SV_ADMIN, groups, georchestra.org
@@ -151,7 +146,6 @@ cn: SV_ADMIN
 ou: 20
 description: This group grants admin access to GeoNetwork
 member: uid=testadmin,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 # SV_EDITOR, groups, georchestra.org
 dn: cn=SV_EDITOR,ou=groups,dc=georchestra,dc=org
@@ -161,7 +155,6 @@ cn: SV_EDITOR
 ou: 21
 description: This group grants edit rights in GeoNetwork and Mapfishapp
 member: uid=testeditor,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 # SV_REVIEWER, groups, georchestra.org
 dn: cn=SV_REVIEWER,ou=groups,dc=georchestra,dc=org
@@ -171,7 +164,6 @@ cn: SV_REVIEWER
 ou: 22
 description: This group grants reviewer rights in GeoNetwork
 member: uid=testreviewer,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 # SV_USER, groups, georchestra.org
 dn: cn=SV_USER,ou=groups,dc=georchestra,dc=org
@@ -181,6 +173,5 @@ cn: SV_USER
 ou: 23
 description: This group grants basic, authenticated access to the whole SDI
 member: uid=testuser,ou=users,dc=georchestra,dc=org
-member: uid=fakeuser
 
 

--- a/georchestra.ldif
+++ b/georchestra.ldif
@@ -93,7 +93,7 @@ ou: groups
 # ADMINISTRATOR, groups, georchestra.org
 dn: cn=ADMINISTRATOR,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: ADMINISTRATOR
 ou: 1
 description: This group grants admin access to GeoServer
@@ -105,7 +105,7 @@ member: uid=fakeuser
 # PENDING_USERS, groups, georchestra.org
 dn: cn=PENDING_USERS,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: PENDING_USERS
 ou: 2
 description: This group does not grant any right inside the SDI. Users in this group are requesting a fully fledged account.
@@ -115,7 +115,7 @@ member: uid=fakeuser
 # MOD_LDAPADMIN, groups, georchestra.org
 dn: cn=MOD_LDAPADMIN,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: MOD_LDAPADMIN
 ou: 10
 description: This group grants access to the LDAPadmin private User Interface
@@ -125,7 +125,7 @@ member: uid=fakeuser
 # MOD_ANALYTICS, groups, georchestra.org
 dn: cn=MOD_ANALYTICS,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: MOD_ANALYTICS
 ou: 11
 description: This group grants access to the Analytics application
@@ -135,7 +135,7 @@ member: uid=fakeuser
 # MOD_EXTRACTORAPP, groups, georchestra.org
 dn: cn=MOD_EXTRACTORAPP,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: MOD_EXTRACTORAPP
 ou: 12
 description: This group grants access to the Extractorapp application
@@ -146,7 +146,7 @@ member: uid=fakeuser
 # SV_ADMIN, groups, georchestra.org
 dn: cn=SV_ADMIN,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: SV_ADMIN
 ou: 20
 description: This group grants admin access to GeoNetwork
@@ -156,7 +156,7 @@ member: uid=fakeuser
 # SV_EDITOR, groups, georchestra.org
 dn: cn=SV_EDITOR,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: SV_EDITOR
 ou: 21
 description: This group grants edit rights in GeoNetwork and Mapfishapp
@@ -166,7 +166,7 @@ member: uid=fakeuser
 # SV_REVIEWER, groups, georchestra.org
 dn: cn=SV_REVIEWER,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: SV_REVIEWER
 ou: 22
 description: This group grants reviewer rights in GeoNetwork
@@ -176,7 +176,7 @@ member: uid=fakeuser
 # SV_USER, groups, georchestra.org
 dn: cn=SV_USER,ou=groups,dc=georchestra,dc=org
 objectClass: top
-objectClass: groupOfNames
+objectClass: groupOfMembers
 cn: SV_USER
 ou: 23
 description: This group grants basic, authenticated access to the whole SDI


### PR DESCRIPTION
groupOfNames doesn't allow to use empty groups, which leads to hacks like fakeuser... groupOfMembers allows this, so let's import this objectClass and use it instead. For more informations on it, see http://www.openldap.org/lists/openldap-technical/201312/msg00038.html and the rfc it references.

I didnt want to replace the whole nis schema by rfc2307bis as per http://bubblesorted.raab.link/content/replace-nis-rfc2307-rfc2307bis-schema-openldap because it seems a bit like a huge hammer.

Tweak memberOf overlay config to trigger on the correct objectClass while here. This PR only takes care of the LDAP example tree & scripts.

I've tested this locally, importing the ldif schema with
```
ldapadd -Y EXTERNAL -H ldapi:/// -f /tmp/georchestra-groupofmembers.ldif
```
and then (using shelldap) creating an empty group, and a group with a member containing a fullDN.